### PR TITLE
Support for WinRM 1.5+

### DIFF
--- a/winrm-elevated.gemspec
+++ b/winrm-elevated.gemspec
@@ -25,8 +25,8 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files = %w(README.md LICENSE)
 
   s.required_ruby_version = '>= 1.9.0'
-  s.add_runtime_dependency 'winrm', '~> 1.3'
-  s.add_runtime_dependency 'winrm-fs', '~> 0.2.2'
+  s.add_runtime_dependency 'winrm', '~> 1.5'
+  s.add_runtime_dependency 'winrm-fs', '~> 0.3.0'
   s.add_development_dependency 'rspec', '~> 3.2'
   s.add_development_dependency 'rake', '~> 10.3'
   s.add_development_dependency 'rubocop', '~> 0.28'


### PR DESCRIPTION
Allow winrm-elevated elevated runners to work alongside WinRM 1.5+
 Executors.  This allows one to run requests that don't require 
"elevation" in a single cmd process, while still running the elevated requests
as winrm-elevated initially designed.  We get the speed advantage of WinRM 1.5
with the authentication advantage of winrm-elevated.