### PR TITLE
Upload Elevated Runner Script Just Once

### DIFF
--- a/lib/winrm-elevated/runner.rb
+++ b/lib/winrm-elevated/runner.rb
@@ -27,6 +27,7 @@ module WinRM
         @winrm_service = winrm_service
         @winrm_file_manager = WinRM::FS::FileManager.new(winrm_service)
         @elevated_shell_path = 'c:/windows/temp/winrm-elevated-shell.ps1'
+        @uploaded            = nil
       end
 
       # Run a command or PowerShell script elevated without any of the
@@ -49,12 +50,14 @@ module WinRM
       private
 
       def upload_elevated_shell_wrapper_script
+        return if @uploaded
         file = Tempfile.new(['winrm-elevated-shell', 'ps1'])
         begin
           file.write(elevated_shell_script_content)
           file.fsync
           file.close
           @winrm_file_manager.upload(file.path, @elevated_shell_path)
+          @uploaded = true
         ensure
           file.close
           file.unlink


### PR DESCRIPTION
Only upload the wrapper shell winrm-elevated-shell.ps1 once per connection.
No need to do so on every command request.

@sneal I broke the previous pull request into two parts as suggested.  This change is relevant no matter the gem version.

Please review and merge when appropriate.