### PR TITLE
Name Powershell Script and Log Files Uniquely

### DIFF
--- a/lib/winrm-elevated/runner.rb
+++ b/lib/winrm-elevated/runner.rb
@@ -16,6 +16,7 @@
 
 require 'winrm'
 require 'winrm-fs'
+require 'securerandom'
 
 module WinRM
   module Elevated
@@ -26,7 +27,7 @@ module WinRM
       def initialize(winrm_service)
         @winrm_service = winrm_service
         @winrm_file_manager = WinRM::FS::FileManager.new(winrm_service)
-        @elevated_shell_path = 'c:/windows/temp/winrm-elevated-shell.ps1'
+        @elevated_shell_path = 'c:/windows/temp/winrm-elevated-shell-' + SecureRandom.uuid + '.ps1'
         @uploaded            = nil
       end
 

--- a/lib/winrm-elevated/scripts/elevated_shell.ps1
+++ b/lib/winrm-elevated/scripts/elevated_shell.ps1
@@ -1,15 +1,8 @@
 param([String]$username, [String]$password, [String]$encoded_command, [String]$timeout)
 
 $task_name = "WinRM_Elevated_Shell"
-$out_file = "$env:Temp\winrm_elevated_out.log"
-$err_file = "$env:Temp\winrm_elevated_err.log"
-
-if (Test-Path $out_file) {
-  del $out_file
-}
-if (Test-Path $err_file) {
-  del $err_file
-}
+$out_file = [System.IO.Path]::GetTempFileName()
+$err_file = [System.IO.Path]::GetTempFileName()
 
 $task_xml = @'
 <?xml version="1.0" encoding="UTF-16"?>
@@ -93,6 +86,9 @@ do {
   $out_cur_line = SlurpOutput $out_file $out_cur_line 'out'
   $err_cur_line = SlurpOutput $err_file $err_cur_line 'err'
 } while (!($registered_task.state -eq 3))
+
+del $out_file
+del $err_file
 
 $exit_code = $registered_task.LastTaskResult
 [System.Runtime.Interopservices.Marshal]::ReleaseComObject($schedule) | Out-Null


### PR DESCRIPTION
In order to allow winrm-elevated to run concurrently against the
same Windows server, name the powershell script uploaded to the server
using a randomly generated UUID.

In addition, the logfiles generated by the script will be named using the
pid of the script's running process.

We will clean up the logfiles when the script is finished. Since the same
script can be uploaded once and invoked multiple times it will be left intact.

The intent here is to deal with the issue described here: https://github.com/WinRb/winrm-elevated/issues/5

@mwrock @sneal if you could review and possibly merge when possible that would be great.
Open for discussion of course.  Thanks!