### PR TITLE
Add ExecutionPolicy Bypass

### DIFF
--- a/lib/winrm-elevated/scripts/elevated_shell.ps1
+++ b/lib/winrm-elevated/scripts/elevated_shell.ps1
@@ -53,7 +53,7 @@ $task_xml = @'
 </Task>
 '@
 
-$arguments = "/c powershell.exe -File $script_file &gt; $out_file 2&gt;$err_file"
+$arguments = "/c powershell.exe -executionpolicy bypass -File $script_file &gt; $out_file 2&gt;$err_file"
 
 $task_xml = $task_xml.Replace("{arguments}", $arguments)
 $task_xml = $task_xml.Replace("{username}", $username)


### PR DESCRIPTION
Fix issue:

C:\windows\temp\winrm-elevated-shell-84d9ed22-695d-493e-95ed-b80c3c600b07.ps1
cannot be loaded because running scripts is disabled on this system. For more
information, see about_Execution_Policies at
http://go.microsoft.com/fwlink/?LinkID=135170.
    + CategoryInfo          : SecurityError: (:) [], ParentContainsErrorRecord
   Exception
    + FullyQualifiedErrorId : UnauthorizedAccess
