### PR TITLE
Add configurable timeouts for execution

### DIFF
--- a/lib/winrm-elevated/scripts/elevated_shell.ps1
+++ b/lib/winrm-elevated/scripts/elevated_shell.ps1
@@ -97,11 +97,13 @@ function SlurpOutput($file, $cur_line, $out_type) {
 
 $err_cur_line = 0
 $out_cur_line = 0
+$timeout = <%= execution_timeout %>
+$startDate = Get-Date
 do {
   Start-Sleep -m 100
   $out_cur_line = SlurpOutput $out_file $out_cur_line 'out'
   $err_cur_line = SlurpOutput $err_file $err_cur_line 'err'
-} while (!($registered_task.state -eq 3))
+} while( (!($registered_task.state -eq 3)) -and ($startDate.AddSeconds($timeout) -gt (Get-Date)) )
 
 # We'll make a best effort to clean these files
 # But a reboot could possibly end the task while the process

--- a/lib/winrm/shells/elevated.rb
+++ b/lib/winrm/shells/elevated.rb
@@ -33,6 +33,7 @@ module WinRM
         @interactive_logon = false
         @shell = Powershell.new(connection_opts, transport, logger)
         @winrm_file_transporter = WinRM::FS::Core::FileTransporter.new(@shell)
+        @execution_timeout = 86_400
       end
 
       # @return [String] The admin user name to execute the scheduled task as
@@ -43,6 +44,9 @@ module WinRM
 
       # @return [Bool] Using an interactive logon
       attr_accessor :interactive_logon
+
+      # @return [Integer] Timeout for the task to be executed
+      attr_accessor :execution_timeout
 
       # Run a command or PowerShell script elevated without any of the
       # restrictions that WinRM puts in place.
@@ -95,7 +99,8 @@ module WinRM
           username: username,
           password: password,
           script_path: script_path,
-          interactive_logon: interactive_logon
+          interactive_logon: interactive_logon,
+          execution_timeout: execution_timeout
         }
 
         b = binding


### PR DESCRIPTION
Hi @mwrock 

I have an issue with the windows tasks scheduler, sometimes the task does not return in the "Ready" (state 3) after the execution.
So the run command does not close. I have some sidekiq jobs that try to execute command for 5 days.
I see that the powershell script have an infinite loop, I propose to implement a timeout that kill the loop after 1 day (the time define in the xml configuration of the task).
The timeout is configurable for the end user.

Could you please consider this change ?

Thank you