### PR TITLE
Port the hash case for the erubis->erubi change from WinRM

### DIFF
--- a/winrm-elevated.gemspec
+++ b/winrm-elevated.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files = %w[README.md LICENSE]
 
   s.required_ruby_version = '>= 2.3.0'
+  s.add_runtime_dependency 'erubi', '~> 1.8'
   s.add_runtime_dependency 'winrm', '~> 2.0'
   s.add_runtime_dependency 'winrm-fs', '~> 1.0'
   s.add_development_dependency 'rake', '>= 10.3', '< 13'


### PR DESCRIPTION
Adapted the change from:
https://github.com/WinRb/WinRM/pull/300

This grabs prior context or local variables, builds a string which set
these variables, and evalulates them in the context of the binding.

Note, this repo wasn't explicitly depending on erubis before but was trying to
require it.  I've also added erubi as a dependency so this gem can run
standalone.

Fixes #28