### PR TITLE
Remove old task and add a unique name

### DIFF
--- a/lib/winrm-elevated/scripts/elevated_shell.ps1
+++ b/lib/winrm-elevated/scripts/elevated_shell.ps1
@@ -16,7 +16,7 @@ if($interactive -eq 'true') {
   $logon_type_xml = "<LogonType>InteractiveTokenOrPassword</LogonType>"
 }
 
-$task_name = "WinRM_Elevated_Shell"
+$task_name = "WinRM_Elevated_Shell_" + (New-Guid).Guid
 $out_file = [System.IO.Path]::GetTempFileName()
 $err_file = [System.IO.Path]::GetTempFileName()
 

--- a/lib/winrm-elevated/scripts/elevated_shell.ps1
+++ b/lib/winrm-elevated/scripts/elevated_shell.ps1
@@ -111,6 +111,9 @@ try { Remove-Item $err_file -ErrorAction Stop } catch {}
 try { Remove-Item $script_file -ErrorAction Stop } catch {}
 
 $exit_code = $registered_task.LastTaskResult
+
+try { Unregister-ScheduledTask -TaskName $task_name -Confirm:$false } catch {}
+
 [System.Runtime.Interopservices.Marshal]::ReleaseComObject($schedule) | Out-Null
 
 exit $exit_code


### PR DESCRIPTION
Last week we had a problem with the ESET antivirus which blocked the XML file of winrm tasks located in C:\Windows\System32\Tasks\WinRM_Elevated_Shell.xml.

After resolution of the problem by ESET, the windows task scheduler was in an inconsistent state. It was no longer possible to create WinRM_Elevated_Shell task.

This PR allows to change the name of the winrm tasks to avoid blocking and to delete the tasks at the end of the script.

It is also possible to multi thread with the gem.