### PR TITLE
Optimize our requires

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,4 @@
-require 'rubygems'
+require 'rubygems' unless defined?(Gem)
 require 'bundler/setup'
 require 'rspec/core/rake_task'
 require 'rubocop/rake_task'

--- a/lib/winrm-elevated.rb
+++ b/lib/winrm-elevated.rb
@@ -13,5 +13,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require 'winrm'
+require 'winrm' unless defined?(WinRM::Connection)
 require_relative 'winrm/shells/elevated'

--- a/lib/winrm/shells/elevated.rb
+++ b/lib/winrm/shells/elevated.rb
@@ -14,9 +14,9 @@
 # limitations under the License.
 
 require 'erubi'
-require 'winrm'
+require 'winrm' unless defined?(WinRM::Connection)
 require 'winrm-fs'
-require 'securerandom'
+require 'securerandom' unless defined?(SecureRandom)
 
 module WinRM
   module Shells

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,4 @@
-require 'winrm'
+require 'winrm' unless defined?(WinRM::Connection)
 require 'winrm-elevated'
 require_relative 'matchers'
 


### PR DESCRIPTION
Avoid requiring things that are already defined. Rubygems is very slow at traversing the filesystem.

Signed-off-by: Tim Smith <tsmith@chef.io>