### PR TITLE
Fix lint offenses and enforce lint in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,8 +49,6 @@ jobs:
 
   lint:
     runs-on: ubuntu-latest
-    # Advisory for now: pre-existing offenses will be cleaned up in a dedicated pass.
-    continue-on-error: true
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:


### PR DESCRIPTION
Removes `continue-on-error: true` from the RuboCop lint job so lint is now required like every other CI check.

RuboCop reports zero offenses across the repo (rubocop 1.91.0), so no code changes were needed — only the workflow flip. The `Gemspec/RequiredRubyVersion` cop is enabled and passes (the gemspec specifies `required_ruby_version >= 2.5.0`, which is intentionally left alone), so no `.rubocop.yml` exclusion was added.