### PR TITLE
Scope CI push trigger to default branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,9 @@
 name: Ruby
 
 on:
-  - push
-  - pull_request
+  push:
+    branches: [main]
+  pull_request:
 
 permissions:
   contents: read # checkout only, nothing else


### PR DESCRIPTION
The workflow triggered on both `push` and `pull_request`, so every push to a PR branch ran the suite twice. Scope the `push` trigger to the default branch only.